### PR TITLE
configure goreleaser to use sha512 algorithm for checksums

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,8 @@ builds:
       goarch: arm64
 
 checksum:
-  name_template: '{{ .ProjectName }}_{{ .Version }}_sha256-checksums.txt'
+  name_template: '{{ .ProjectName }}_{{ .Version }}_sha512-checksums.txt'
+  algorithm: sha512
 
 archive:
   format: tar.gz


### PR DESCRIPTION
This change modifies the configuration of goreleaser to generate checksums using the sha512 algorithm, as this is most expedient for use with Sensu Go and/or Bonsai.