### PR TITLE
Remove Darwin 386 from .bonsai.yml

### DIFF
--- a/.bonsai.yml
+++ b/.bonsai.yml
@@ -33,14 +33,6 @@ builds:
   -  "entity.system.os == 'darwin'"
   -  "entity.system.arch == 'amd64'"
 
-- platform: "OSX"
-  arch: "386"
-  asset_filename: "#{repo}_#{version}_darwin_386.tar.gz"
-  sha_filename: "#{repo}_#{version}_sha512-checksums.txt"
-  filter:
-  -  "entity.system.os == 'darwin'"
-  -  "entity.system.arch == '386'"
-
 - platform: "Windows"
   arch: "amd64"
   asset_filename: "#{repo}_#{version}_windows_amd64.tar.gz"


### PR DESCRIPTION
Darwin 386 is explicitly ignored in goreleaser config, and the presence of this entry renders the asset unusable on the live Bonsai site.