### PR TITLE
Js/create state directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -257,12 +257,14 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if plugin.StateDir == "" {
 		return sensu.CheckStateCritical, fmt.Errorf("--state-directory not specified")
 	}
-	_, err := os.Stat(plugin.StateDir)
-	if errors.Is(err, os.ErrNotExist) {
-		return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist", plugin.StateDir)
+	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
+		err := os.Mkdir(plugin.StateDir, os.ModePerm)
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.", plugin.StateDir)
+		}
 	}
-	if plugin.MatchExpr == "" {
-		return sensu.CheckStateCritical, fmt.Errorf("--match-expr not specified")
+	if _, err := os.Stat(plugin.StateDir); err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("Unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
 	}
 	if plugin.DryRun {
 		plugin.Verbose = true

--- a/main_test.go
+++ b/main_test.go
@@ -72,15 +72,16 @@ func TestCheckArgs(t *testing.T) {
 	assert.Equal(t, 2, status)
 	plugin.StateDir = "missing_dir"
 	status, err = checkArgs(event)
-	assert.Error(t, err)
-	assert.Equal(t, 2, status)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, status)
 	td, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
 	defer os.RemoveAll(td)
 	plugin.StateDir = td
 	status, err = checkArgs(event)
-	assert.Error(t, err)
-	assert.Equal(t, 2, status)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, status)
+	defer os.RemoveAll(td)
 	plugin.MatchExpr = "error"
 	status, err = checkArgs(event)
 	assert.NoError(t, err)


### PR DESCRIPTION
Have the check attempt to create the state directory if missing.  
This is a feature parity issue with the older ruby plugin check