### PR TITLE
fix filepath regexp so that it matches directory as well as filename

### DIFF
--- a/main.go
+++ b/main.go
@@ -380,10 +380,13 @@ func buildLogArray() error {
 			return e
 		}
 		absLogPath, _ := filepath.Abs(plugin.LogPath)
+		if plugin.Verbose {
+			fmt.Printf("Searching for matching file names in: %v\n", absLogPath)
+		}
 
 		if filepath.IsAbs(absLogPath) {
 			e = filepath.Walk(absLogPath, func(path string, info os.FileInfo, err error) error {
-				if err == nil && logRegExp.MatchString(info.Name()) {
+				if err == nil && logRegExp.MatchString(path) {
 					if filepath.IsAbs(path) {
 						if !info.IsDir() {
 							logs = append(logs, path)

--- a/main_test.go
+++ b/main_test.go
@@ -173,7 +173,11 @@ func TestBuildLogArray(t *testing.T) {
 		t.Errorf("BuildLogArray len %v", len(logs))
 	}
 	for _, log := range logs {
-		assert.Contains(t, log, "/testingdata/test.log")
+		if runtime.GOOS != "windows" {
+			assert.Contains(t, log, `/testingdata/test.log`)
+		} else {
+			assert.Contains(t, log, `\testingdata\test.log`)
+		}
 	}
 	logs = []string{}
 	plugin.LogFile = ""
@@ -188,7 +192,11 @@ func TestBuildLogArray(t *testing.T) {
 		t.Errorf("BuildLogArray len %v", len(logs))
 	}
 	for _, log := range logs {
-		assert.Contains(t, log, "/testingdata/test.log")
+		if runtime.GOOS != "windows" {
+			assert.Contains(t, log, `/testingdata/test.log`)
+		} else {
+			assert.Contains(t, log, `\testingdata\test.log`)
+		}
 	}
 	logs = []string{}
 	plugin.LogFile = ""

--- a/main_test.go
+++ b/main_test.go
@@ -157,9 +157,26 @@ func TestState(t *testing.T) {
 func TestBuildLogArray(t *testing.T) {
 	err := buildLogArray()
 	assert.NoError(t, err)
-	plugin.LogFile = "./testingdata/test.log"
 	err = os.Chmod("./testingdata/test.log", 0755)
 	assert.NoError(t, err)
+
+	logs = []string{}
+	plugin.LogFile = "./testingdata/test.log"
+	plugin.LogPath = ""
+	plugin.LogFileExpr = ""
+	plugin.Verbose = false
+	err = buildLogArray()
+	if err != nil {
+		t.Errorf("BuildLogArray err: %s", err)
+	}
+	if len(logs) != 1 {
+		t.Errorf("BuildLogArray len %v", len(logs))
+	}
+	for _, log := range logs {
+		assert.Contains(t, log, "/testingdata/test.log")
+	}
+	logs = []string{}
+	plugin.LogFile = ""
 	plugin.LogPath = "testingdata/"
 	plugin.LogFileExpr = "test.log"
 	plugin.Verbose = false
@@ -169,6 +186,24 @@ func TestBuildLogArray(t *testing.T) {
 	}
 	if len(logs) != 1 {
 		t.Errorf("BuildLogArray len %v", len(logs))
+	}
+	for _, log := range logs {
+		assert.Contains(t, log, "/testingdata/test.log")
+	}
+	logs = []string{}
+	plugin.LogFile = ""
+	plugin.LogPath = `testingdata/`
+	plugin.LogFileExpr = `webserver`
+	plugin.Verbose = false
+	err = buildLogArray()
+	if err != nil {
+		t.Errorf("BuildLogArray err: %s", err)
+	}
+	if len(logs) != 3 {
+		t.Errorf("BuildLogArray len %v", len(logs))
+	}
+	for _, log := range logs {
+		assert.Contains(t, log, "access.log")
 	}
 
 }

--- a/main_test.go
+++ b/main_test.go
@@ -156,6 +156,7 @@ func TestState(t *testing.T) {
 
 func TestBuildLogArray(t *testing.T) {
 	logs, err := buildLogArray()
+	assert.Equal(t, 0, len(logs))
 	assert.NoError(t, err)
 	err = os.Chmod("./testingdata/test.log", 0755)
 	assert.NoError(t, err)
@@ -369,7 +370,6 @@ func TestProcessLogFile(t *testing.T) {
 	assert.Equal(t, 1, matches)
 
 	// test for abs log file path err
-	logs = []string{}
 	td, err = ioutil.TempDir("", "")
 	defer os.RemoveAll(td)
 	assert.NoError(t, err)

--- a/main_test.go
+++ b/main_test.go
@@ -155,17 +155,16 @@ func TestState(t *testing.T) {
 }
 
 func TestBuildLogArray(t *testing.T) {
-	err := buildLogArray()
+	logs, err := buildLogArray()
 	assert.NoError(t, err)
 	err = os.Chmod("./testingdata/test.log", 0755)
 	assert.NoError(t, err)
 
-	logs = []string{}
 	plugin.LogFile = "./testingdata/test.log"
 	plugin.LogPath = ""
 	plugin.LogFileExpr = ""
 	plugin.Verbose = false
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	if err != nil {
 		t.Errorf("BuildLogArray err: %s", err)
 	}
@@ -179,12 +178,11 @@ func TestBuildLogArray(t *testing.T) {
 			assert.Contains(t, log, `\testingdata\test.log`)
 		}
 	}
-	logs = []string{}
 	plugin.LogFile = ""
 	plugin.LogPath = "testingdata/"
 	plugin.LogFileExpr = "test.log"
 	plugin.Verbose = false
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	if err != nil {
 		t.Errorf("BuildLogArray err: %s", err)
 	}
@@ -198,12 +196,11 @@ func TestBuildLogArray(t *testing.T) {
 			assert.Contains(t, log, `\testingdata\test.log`)
 		}
 	}
-	logs = []string{}
 	plugin.LogFile = ""
 	plugin.LogPath = `testingdata/`
 	plugin.LogFileExpr = `webserver`
 	plugin.Verbose = false
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	if err != nil {
 		t.Errorf("BuildLogArray err: %s", err)
 	}
@@ -346,7 +343,6 @@ func TestProcessLogFile(t *testing.T) {
 	plugin.MaxBytes = 4000
 	plugin.Procs = 1
 	plugin.DisableEvent = true
-	logs = []string{}
 	plugin.LogFile = "./testingdata/test.log"
 	plugin.MatchExpr = "test"
 
@@ -360,14 +356,13 @@ func TestProcessLogFile(t *testing.T) {
 	enc := json.NewEncoder(eventBuf)
 
 	// test for good match
-	logs = []string{}
 	td, err = ioutil.TempDir("", "")
 	defer os.RemoveAll(td)
 	assert.NoError(t, err)
 	plugin.StateDir = td
 	plugin.MatchExpr = "test"
 	plugin.WarningOnly = true
-	err = buildLogArray()
+	logs, err := buildLogArray()
 	assert.NoError(t, err)
 	matches, err := processLogFile(logs[0], enc)
 	assert.NoError(t, err)
@@ -382,7 +377,7 @@ func TestProcessLogFile(t *testing.T) {
 	matches, err = processLogFile(plugin.LogFile, enc)
 	assert.Error(t, err)
 	assert.Equal(t, 0, matches)
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	assert.NoError(t, err)
 	matches, err = processLogFile(logs[0], enc)
 	assert.NoError(t, err)
@@ -390,12 +385,11 @@ func TestProcessLogFile(t *testing.T) {
 
 	// test for IgnoreFirstRun
 	plugin.IgnoreInitialRun = true
-	logs = []string{}
 	td, err = ioutil.TempDir("", "")
 	defer os.RemoveAll(td)
 	assert.NoError(t, err)
 	plugin.StateDir = td
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	assert.NoError(t, err)
 	matches, err = processLogFile(logs[0], enc)
 	assert.NoError(t, err)
@@ -405,7 +399,7 @@ func TestProcessLogFile(t *testing.T) {
 	defer os.RemoveAll(td)
 	assert.NoError(t, err)
 	plugin.StateDir = td
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	assert.NoError(t, err)
 	matches, err = processLogFile(logs[0], enc)
 	assert.NoError(t, err)
@@ -471,7 +465,6 @@ func TestProcessLogFileRotatedFile(t *testing.T) {
 	plugin.Procs = 1
 	plugin.DisableEvent = true
 	plugin.MatchExpr = "brown"
-	logs = []string{}
 
 	td, err := ioutil.TempDir("", "")
 	assert.NoError(t, err)
@@ -495,7 +488,7 @@ func TestProcessLogFileRotatedFile(t *testing.T) {
 	eventBuf := new(bytes.Buffer)
 	enc := json.NewEncoder(eventBuf)
 
-	err = buildLogArray()
+	logs, err := buildLogArray()
 	assert.NoError(t, err)
 	matches, err := processLogFile(logs[0], enc)
 	assert.NoError(t, err)
@@ -511,7 +504,7 @@ func TestProcessLogFileRotatedFile(t *testing.T) {
 	f.Close()
 	_, err = ioutil.ReadFile(plugin.LogFile)
 	assert.NoError(t, err)
-	err = buildLogArray()
+	logs, err = buildLogArray()
 	assert.NoError(t, err)
 	matches, err = processLogFile(logs[0], enc)
 	assert.NoError(t, err)

--- a/testingdata/old-webserver-00/access.log
+++ b/testingdata/old-webserver-00/access.log
@@ -1,0 +1,1 @@
+this is a webserver test log

--- a/testingdata/webserver-01/access.log
+++ b/testingdata/webserver-01/access.log
@@ -1,0 +1,7 @@
+this is a webserver test log
+this is a webserver test log
+this is a webserver test log
+this is a webserver test log
+this is a webserver test log
+this is a webserver test log
+this is a webserver test log

--- a/testingdata/webserver-02/access.log
+++ b/testingdata/webserver-02/access.log
@@ -1,0 +1,1 @@
+this is a webserver test log


### PR DESCRIPTION
The existing implementation of the filepath regexp is actually a filename regexp.
This PR changes the implementation to the intended filepath regexp so that you can do regexp matches for directory components of the full file path.

Tests were updated to include a regexp test for subdirectory matching.