### PR TITLE
fix for incorrect end of file logic in state directory

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -494,6 +494,11 @@ func TestProcessLogFileRotatedFile(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 1, matches)
 
+	//re-run should have no new matches
+	matches, err = processLogFile(logs[0], enc)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, matches)
+
 	//rotate the file
 	os.Remove(plugin.LogFile)
 	f, err = os.OpenFile(plugin.LogFile,


### PR DESCRIPTION
Closes #23 

Fix for incorrect logic when handling cached file offset that corresponds to end of file.

Added new test for this condition.