### PR TITLE
fix for return status when processing multiple files

### DIFF
--- a/main.go
+++ b/main.go
@@ -538,8 +538,7 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 	return numResults, nil
 }
 
-func setStatus(numMatches int) int {
-
+func setStatus(currentStatus int, numMatches int) int {
 	status := sensu.CheckStateOK
 	warn := false
 	critical := false
@@ -566,11 +565,16 @@ func setStatus(numMatches int) int {
 			status = sensu.CheckStateCritical
 		}
 	}
-	return status
+	if status > currentStatus {
+		return status
+	} else {
+		return currentStatus
+	}
 }
 
 func executeCheck(event *corev2.Event) (int, error) {
 	var status int
+	status = 0
 	logs, e := buildLogArray()
 	if e != nil {
 		return sensu.CheckStateCritical, e
@@ -587,7 +591,7 @@ func executeCheck(event *corev2.Event) (int, error) {
 			status = sensu.CheckStateOK
 			continue
 		}
-		status = setStatus(numMatches)
+		status = setStatus(status, numMatches)
 
 	} // end of loop over log files
 	if len(fileErrors) > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -51,30 +51,109 @@ func TestStdin(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, false, test)
 }
-func TestSetStatus(t *testing.T) {
+
+func TestSettStatusWithCurrentStatusZero(t *testing.T) {
 	clearPlugin()
+	s := 0
 	numMatches := 10
-	status := setStatus(numMatches)
+	status := setStatus(s, numMatches)
 	assert.Equal(t, 0, status)
 	plugin.WarningThreshold = 1
-	status = setStatus(numMatches)
+	status = setStatus(s, numMatches)
 	assert.Equal(t, 1, status)
 	plugin.WarningThreshold = 11
-	status = setStatus(numMatches)
+	status = setStatus(s, numMatches)
 	assert.Equal(t, 0, status)
 	plugin.WarningThreshold = 1
 	plugin.CriticalThreshold = 8
-	status = setStatus(numMatches)
+	status = setStatus(s, numMatches)
 	assert.Equal(t, 2, status)
 	plugin.WarningOnly = true
-	status = setStatus(numMatches)
+	status = setStatus(s, numMatches)
 	assert.Equal(t, 1, status)
 	plugin.CriticalOnly = true
 	plugin.WarningOnly = false
 	numMatches = 5
-	status = setStatus(numMatches)
+	status = setStatus(s, numMatches)
 	assert.Equal(t, 0, status)
 }
+
+func TestSettStatusWithCurrentStatusOne(t *testing.T) {
+	clearPlugin()
+	s := 1
+	numMatches := 10
+	status := setStatus(s, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.WarningThreshold = 1
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.WarningThreshold = 11
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.WarningThreshold = 1
+	plugin.CriticalThreshold = 8
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningOnly = true
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.CriticalOnly = true
+	plugin.WarningOnly = false
+	numMatches = 5
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 1, status)
+}
+func TestSettStatusWithCurrentStatusTwo(t *testing.T) {
+	clearPlugin()
+	s := 2
+	numMatches := 10
+	status := setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningThreshold = 1
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningThreshold = 11
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningThreshold = 1
+	plugin.CriticalThreshold = 8
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningOnly = true
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.CriticalOnly = true
+	plugin.WarningOnly = false
+	numMatches = 5
+	status = setStatus(s, numMatches)
+	assert.Equal(t, 2, status)
+}
+
+func TestSetStatus(t *testing.T) {
+	clearPlugin()
+	numMatches := 10
+	status := setStatus(0, numMatches)
+	assert.Equal(t, 0, status)
+	plugin.WarningThreshold = 1
+	status = setStatus(0, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.WarningThreshold = 11
+	status = setStatus(0, numMatches)
+	assert.Equal(t, 0, status)
+	plugin.WarningThreshold = 1
+	plugin.CriticalThreshold = 8
+	status = setStatus(0, numMatches)
+	assert.Equal(t, 2, status)
+	plugin.WarningOnly = true
+	status = setStatus(0, numMatches)
+	assert.Equal(t, 1, status)
+	plugin.CriticalOnly = true
+	plugin.WarningOnly = false
+	numMatches = 5
+	status = setStatus(0, numMatches)
+	assert.Equal(t, 0, status)
+}
+
 func TestCheckArgs(t *testing.T) {
 	clearPlugin()
 	status, err := checkArgs(nil)


### PR DESCRIPTION
Closes #25 

Multiple file processing logic was incomplete, was not properly tracking appropriate return status for the collection of log files.

This pull request includes logic fix to SetStatus so that it considers a pre-existing current status to use a minimum return value instead of assuming zero status is always a valid return.

Pull request also includes refactored SetStatus tests to test condition with current status is 0,1,2 to ensure correct operation