### PR TITLE
Js/fix broken verbose check

### DIFF
--- a/main.go
+++ b/main.go
@@ -486,10 +486,8 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 
 	if offset > 0 {
 		if offset == info.Size() {
-			if plugin.Verbose {
-				fmt.Printf("Cached offset in state directory for %s indicates file not updated since last read\n", file)
-				return 0, nil
-			}
+			fmt.Printf("Cached offset in state directory for %s indicates file not updated since last read\n", file)
+			return 0, nil
 		} else {
 			if _, err := f.Seek(offset, io.SeekStart); err != nil {
 				return 0, fmt.Errorf("error couldn't seek file %s to offset %d: %s", file, offset, err)

--- a/main.go
+++ b/main.go
@@ -486,7 +486,9 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 
 	if offset > 0 {
 		if offset == info.Size() {
-			fmt.Printf("Cached offset in state directory for %s indicates file not updated since last read\n", file)
+			if plugin.Verbose {
+				fmt.Printf("Cached offset in state directory for %s indicates file not updated since last read\n", file)
+			}
 			return 0, nil
 		} else {
 			if _, err := f.Seek(offset, io.SeekStart); err != nil {


### PR DESCRIPTION
Misplaced verbose output logic causing incorrect processinging for stale log file situation resulting in reprocessing of the same lines repeatedly.

Test coverage only tested with verbose set

First commit in PR adds failing test
Second commit fixes new failing test