### PR TITLE
Track file offset for each matching log line, and output as result json

### DIFF
--- a/main.go
+++ b/main.go
@@ -477,7 +477,7 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 	// Are we looking at freshly rotated file since last time we run?
 	// If so let's reset the offset back to 0 and read the file again
 	if offset < 0 {
-		offset = 0
+		return 0, fmt.Errorf("error file %s: cached offset is less than 0, possibly corrupt state file: %s", file, stateFile)
 	}
 	if offset > info.Size() {
 		offset = 0

--- a/main.go
+++ b/main.go
@@ -476,7 +476,9 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 	offset := state.Offset
 	// Are we looking at freshly rotated file since last time we run?
 	// If so let's reset the offset back to 0 and read the file again
-
+	if offset < 0 {
+		offset = 0
+	}
 	if offset > info.Size() {
 		offset = 0
 		if plugin.Verbose {
@@ -504,10 +506,11 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 	}
 
 	analyzer := Analyzer{
-		Path:  file,
-		Procs: plugin.Procs,
-		Log:   reader,
-		Func:  AnalyzeRegexp(plugin.MatchExpr),
+		Path:   file,
+		Procs:  plugin.Procs,
+		Log:    reader,
+		Offset: offset,
+		Func:   AnalyzeRegexp(plugin.MatchExpr),
 	}
 
 	status := sensu.CheckStateOK

--- a/main_test.go
+++ b/main_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -625,7 +626,7 @@ func TestProcessLogFileRotatedFileVerboseFalse(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(logdir)
 
-	plugin.LogFile = logdir + "/test.log"
+	plugin.LogFile = path.Join(logdir, "test.log")
 	f, err := os.OpenFile(plugin.LogFile,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	assert.NoError(t, err)
@@ -697,7 +698,7 @@ func TestProcessLogFileWithNegativeCachedOffset(t *testing.T) {
 	assert.NoError(t, err)
 	defer os.RemoveAll(logdir)
 
-	plugin.LogFile = logdir + "/test.log"
+	plugin.LogFile = path.Join(logdir, "test.log")
 	f, err := os.OpenFile(plugin.LogFile,
 		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	assert.NoError(t, err)
@@ -705,7 +706,7 @@ func TestProcessLogFileWithNegativeCachedOffset(t *testing.T) {
 	assert.NoError(t, err)
 	f.Close()
 
-	stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll("test.log", string(os.PathSeparator), string("_")))
+	stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll(plugin.LogFile, string(os.PathSeparator), string("_")))
 	state, err := getState(stateFile)
 	assert.NoError(t, err)
 	state.Offset = -10

--- a/main_test.go
+++ b/main_test.go
@@ -683,43 +683,44 @@ func TestProcessLogFileRotatedFileVerboseFalse(t *testing.T) {
 
 func TestProcessLogFileWithNegativeCachedOffset(t *testing.T) {
 
-	clearPlugin()
-	plugin.Verbose = false
-	plugin.Procs = 1
-	plugin.DisableEvent = true
-	plugin.MatchExpr = "brown"
+	if runtime.GOOS != "windows" {
+		clearPlugin()
+		plugin.Verbose = false
+		plugin.Procs = 1
+		plugin.DisableEvent = true
+		plugin.MatchExpr = "brown"
 
-	td, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(td)
-	plugin.StateDir = td
+		td, err := ioutil.TempDir("", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(td)
+		plugin.StateDir = td
 
-	logdir, err := ioutil.TempDir("", "")
-	assert.NoError(t, err)
-	defer os.RemoveAll(logdir)
+		logdir, err := ioutil.TempDir("", "")
+		assert.NoError(t, err)
+		defer os.RemoveAll(logdir)
 
-	plugin.LogFile = path.Join(logdir, "test.log")
-	f, err := os.OpenFile(plugin.LogFile,
-		os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	assert.NoError(t, err)
-	_, err = f.WriteString("what now brown cow\n")
-	assert.NoError(t, err)
-	f.Close()
+		plugin.LogFile = path.Join(logdir, "test.log")
+		f, err := os.OpenFile(plugin.LogFile,
+			os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		assert.NoError(t, err)
+		_, err = f.WriteString("what now brown cow\n")
+		assert.NoError(t, err)
+		f.Close()
 
-	stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll(plugin.LogFile, string(os.PathSeparator), string("_")))
-	state, err := getState(stateFile)
-	assert.NoError(t, err)
-	state.Offset = -10
-	err = setState(state, stateFile)
-	assert.NoError(t, err)
+		stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll(plugin.LogFile, string(os.PathSeparator), string("_")))
+		state, err := getState(stateFile)
+		assert.NoError(t, err)
+		state.Offset = -10
+		err = setState(state, stateFile)
+		assert.NoError(t, err)
 
-	eventBuf := new(bytes.Buffer)
-	enc := json.NewEncoder(eventBuf)
+		eventBuf := new(bytes.Buffer)
+		enc := json.NewEncoder(eventBuf)
 
-	logs, err := buildLogArray()
-	assert.NoError(t, err)
-	matches, err := processLogFile(logs[0], enc)
-	assert.Error(t, err)
-	assert.Equal(t, 0, matches)
-
+		logs, err := buildLogArray()
+		assert.NoError(t, err)
+		matches, err := processLogFile(logs[0], enc)
+		assert.Error(t, err)
+		assert.Equal(t, 0, matches)
+	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -705,7 +705,7 @@ func TestProcessLogFileWithNegativeCachedOffset(t *testing.T) {
 	assert.NoError(t, err)
 	f.Close()
 
-	stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll(plugin.LogFile, string(os.PathSeparator), string("_")))
+	stateFile := filepath.Join(plugin.StateDir, strings.ReplaceAll("test.log", string(os.PathSeparator), string("_")))
 	state, err := getState(stateFile)
 	assert.NoError(t, err)
 	state.Offset = -10

--- a/testingdata/webserver-01/access.log
+++ b/testingdata/webserver-01/access.log
@@ -1,7 +1,7 @@
-this is a webserver test log
-this is a webserver test log
-this is a webserver test log
-this is a webserver test log
-this is a webserver test log
-this is a webserver test log
-this is a webserver test log
+this is a webserver test log msg 1
+this is a webserver test log msg 2
+this is a webserver test log msg 3
+this is a webserver test log msg 4
+this is a webserver test log msg 5
+this is a webserver test log msg 6
+this is a webserver test log msg 7


### PR DESCRIPTION
Adjusting how the analyzer is implemented so that file offset for each matching line is tracked.

This is useful for when log file has non-unique matching log lines as you can use the byte offset information to seek to the specific matching line in the log file.