### PR TITLE
Error handling with incorrect argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use summary output by default in generated events
 * Include files with zero matching lines in summary output
 * typo in long argument for invert-thresholds
+* In case wrong argument is passed to `state-directory` only the error will be shown and not the help arguments along
 
 ## [0.6.0] - 2022-05-05
 

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
@@ -311,19 +310,6 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if plugin.MatchExpr == "" {
 		return sensu.CheckStateCritical, fmt.Errorf("--match-expr not specified")
 	}
-	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(plugin.StateDir, os.ModePerm)
-		if err != nil {
-			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
-			fmt.Println(err.Error())
-			logrus.Exit(sensu.CheckStateCritical)
-			//return sensu.CheckStateCritical, nil
-			//return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
-		}
-	}
-	if _, err := os.Stat(plugin.StateDir); err != nil {
-		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
-	}
 	if plugin.DryRun {
 		plugin.Verbose = true
 		fmt.Printf("LogFileExpr: %s StateDir: %s\n", plugin.LogFileExpr, plugin.StateDir)
@@ -349,9 +335,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	//check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
 	check := sensu.NewCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
-	//fmt.Println("Check==", check.)
 	check.Execute()
 }
 
@@ -602,6 +586,17 @@ func setStatus(currentStatus int, numMatches int) int {
 func executeCheck(event *corev2.Event) (int, error) {
 	var status int
 	status = 0
+	//create the state dir if not present
+	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
+		err2 := os.Mkdir(plugin.StateDir, os.ModePerm)
+		if err2 != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
+		}
+	}
+	if _, err := os.Stat(plugin.StateDir); err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
+	}
+
 	logs, e := buildLogArray()
 	if e != nil {
 		return sensu.CheckStateCritical, e


### PR DESCRIPTION
**Closed** https://github.com/sensu/sensu-check-log/issues/37

## Description
The incorrect argument when passed in --state-dir flag must throw up a valid error .

##  Change in behavior
The incorrect argument passed in --state-dir flag will throw up only the error causing the command to command and no --help flags will be shown.

### Added
--

## Changed
Since the agrument is passed to --stae-dir ,no suggessted argument list from help should be displayed .Only the error regarding wrong argument will be shown in command line.

## Fixed
A better error handling is dealt here.

Change verification
Screenshot of the error handling is attached .
<img width="1349" alt="image" src="https://github.com/sensu/sensu-check-log/assets/138477142/696dfc6e-f66c-4e77-8b73-d51ace0fdad6">

