### PR TITLE
recurcive state directory creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use summary output by default in generated events
 * Include files with zero matching lines in summary output
 * typo in long argument for invert-thresholds
+* creation of `state-directory` with a provided recursive path is made possible. 
 
 ## [0.6.0] - 2022-05-05
 

--- a/main.go
+++ b/main.go
@@ -314,11 +314,11 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
 		err := os.Mkdir(plugin.StateDir, os.ModePerm)
 		if err != nil {
-			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory.", plugin.StateDir)
+			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
 			fmt.Println(err.Error())
-			//return sensu.CheckStateCritical, nil
 			logrus.Exit(sensu.CheckStateCritical)
-			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory ", plugin.StateDir)
+			//return sensu.CheckStateCritical, nil
+			//return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
 		}
 	}
 	if _, err := os.Stat(plugin.StateDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
@@ -312,12 +311,13 @@ func checkArgs(event *corev2.Event) (int, error) {
 		return sensu.CheckStateCritical, fmt.Errorf("--match-expr not specified")
 	}
 	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
-		err := os.Mkdir(plugin.StateDir, os.ModePerm)
+		//err := os.Mkdir(plugin.StateDir, os.ModePerm)
+		err := os.MkdirAll(plugin.StateDir, os.ModePerm)
 		if err != nil {
 			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
 			fmt.Println(err.Error())
-			logrus.Exit(sensu.CheckStateCritical)
-			//return sensu.CheckStateCritical, nil
+			//logrus.Exit(sensu.CheckStateCritical)
+			return sensu.CheckStateCritical, nil
 			//return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -314,8 +314,8 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
 		err := os.Mkdir(plugin.StateDir, os.ModePerm)
 		if err != nil {
-			//err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory.", plugin.StateDir)
-			//fmt.Println(err.Error())
+			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory.", plugin.StateDir)
+			fmt.Println(err.Error())
 			//return sensu.CheckStateCritical, nil
 			logrus.Exit(sensu.CheckStateCritical)
 			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory ", plugin.StateDir)

--- a/main.go
+++ b/main.go
@@ -311,14 +311,10 @@ func checkArgs(event *corev2.Event) (int, error) {
 		return sensu.CheckStateCritical, fmt.Errorf("--match-expr not specified")
 	}
 	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
-		//err := os.Mkdir(plugin.StateDir, os.ModePerm)
+		//creating recursive directories incase
 		err := os.MkdirAll(plugin.StateDir, os.ModePerm)
 		if err != nil {
-			err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
-			fmt.Println(err.Error())
-			//logrus.Exit(sensu.CheckStateCritical)
-			return sensu.CheckStateCritical, nil
-			//return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
+			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
 		}
 	}
 	if _, err := os.Stat(plugin.StateDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -7,15 +7,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
-
-	corev2 "github.com/sensu/core/v2"
-	"github.com/sensu/sensu-plugin-sdk/sensu"
 )
 
 // Config represents the check plugin config.
@@ -310,16 +309,6 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if plugin.MatchExpr == "" {
 		return sensu.CheckStateCritical, fmt.Errorf("--match-expr not specified")
 	}
-	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
-		//creating recursive directories incase
-		err := os.MkdirAll(plugin.StateDir, os.ModePerm)
-		if err != nil {
-			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
-		}
-	}
-	if _, err := os.Stat(plugin.StateDir); err != nil {
-		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
-	}
 	if plugin.DryRun {
 		plugin.Verbose = true
 		fmt.Printf("LogFileExpr: %s StateDir: %s\n", plugin.LogFileExpr, plugin.StateDir)
@@ -598,6 +587,19 @@ func setStatus(currentStatus int, numMatches int) int {
 func executeCheck(event *corev2.Event) (int, error) {
 	var status int
 	status = 0
+
+	//create state directory if not existing already
+	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
+		//creating recursive directories incase
+		err := os.MkdirAll(plugin.StateDir, os.ModePerm)
+		if err != nil {
+			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory", plugin.StateDir)
+		}
+	}
+	if _, err := os.Stat(plugin.StateDir); err != nil {
+		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
+	}
+
 	logs, e := buildLogArray()
 	if e != nil {
 		return sensu.CheckStateCritical, e

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
@@ -313,7 +314,11 @@ func checkArgs(event *corev2.Event) (int, error) {
 	if _, err := os.Stat(plugin.StateDir); errors.Is(err, os.ErrNotExist) {
 		err := os.Mkdir(plugin.StateDir, os.ModePerm)
 		if err != nil {
-			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created", plugin.StateDir)
+			//err = fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory.", plugin.StateDir)
+			//fmt.Println(err.Error())
+			//return sensu.CheckStateCritical, nil
+			logrus.Exit(sensu.CheckStateCritical)
+			return sensu.CheckStateCritical, fmt.Errorf("selected --state-directory %s does not exist and cannot be created.Expected a correct Path to create/reach the directory ", plugin.StateDir)
 		}
 	}
 	if _, err := os.Stat(plugin.StateDir); err != nil {
@@ -344,7 +349,9 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
+	//check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
+	check := sensu.NewCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
+	//fmt.Println("Check==", check.)
 	check.Execute()
 }
 
@@ -540,7 +547,8 @@ func processLogFile(file string, enc *json.Encoder) (int, error) {
 	state.Offset = int64(offset + bytesRead)
 	state.MatchExpr = plugin.MatchExpr
 	if plugin.Verbose {
-		fmt.Printf("File %s Match Status %v BytesRead: %v New Offset: %v\n", file, status, bytesRead, state.Offset)
+		fmt.Printf("File %s Match Status %v BytesRead: %v"+
+			" New Offset: %v\n", file, status, bytesRead, state.Offset)
 	}
 
 	if err := setState(state, stateFile); err != nil {

--- a/main.go
+++ b/main.go
@@ -7,14 +7,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	corev2 "github.com/sensu/core/v2"
-	"github.com/sensu/sensu-plugin-sdk/sensu"
 	"io"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
+
+	corev2 "github.com/sensu/core/v2"
+	"github.com/sensu/sensu-plugin-sdk/sensu"
 )
 
 // Config represents the check plugin config.
@@ -334,9 +335,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	//check := sensu.NewGoCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
 	check := sensu.NewCheck(&plugin.PluginConfig, options, checkArgs, executeCheck, useStdin)
-	//fmt.Println("Check==", check.)
 	check.Execute()
 }
 
@@ -597,7 +596,7 @@ func executeCheck(event *corev2.Event) (int, error) {
 		}
 	}
 	if _, err := os.Stat(plugin.StateDir); err != nil {
-		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err)
+		return sensu.CheckStateCritical, fmt.Errorf("unexpected error accessing --state-directory %s: %s", plugin.StateDir, err.Error())
 	}
 
 	logs, e := buildLogArray()


### PR DESCRIPTION
Closed https://github.com/sensu/sensu-check-log/issues/40

## Description
The state-dir argument must be able to create directory recursively.

## Change in behaviour
- Now the complete recursive directory gets created based on state-dir parameter value

### Added
--

### Changed
--

## Fixed
- A recursive directory path parameter is allowed with "state-dir" flag. Creation of requested recursive directory will happen.

## Change verification
Screenshot is attached with requested parameter state-dir `./Parent/subdirectory` , where Parent directory wasn't existing already.

<img width="1667" alt="image" src="https://github.com/sensu/sensu-check-log/assets/138477142/7ff9b831-f42c-43a1-9021-dae7fd5035c4">
