### PR TITLE
Adding a mtime style flag to filter out log files based on modification time

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Flags:
 |--missing-ok               |CHECK_LOG_MISSING_OK               |
 |--invert-thresholds        |CHECK_LOG_INVERT_THRESHOLDS        |
 |--reset-state              |CHECK_LOG_RESET_STATE              |
-|--use-latest-mtime         |CHECK_LOG_USE_LATEST_MTIME         |
+|--mtime                    |CHECK_LOG_MTIME                    |
 
 ### Event generation
 

--- a/README.md
+++ b/README.md
@@ -203,24 +203,6 @@ spec:
 
 ```
 
-Example of configuring a check to monitor only the most recently modified log file when multiple files match the pattern (useful for log rotation scenarios):
-
-```yml
----
-type: CheckConfig
-api_version: core/v2
-metadata:
-  name: sensu-check-log-latest
-spec:  
-  command: sensu-check-log -p /var/log/ -e "application.*\.log$" -m "(?i)error" -d /tmp/sensu-check-latest-log/ --use-latest-mtime
-  stdin: true
-  runtime_assets:
-  - sensu/sensu-check-log
-
-```
-
-
-
 ## Installation from source
 
 The preferred way of installing and deploying this plugin is to use it as an Asset. If you would
@@ -237,14 +219,13 @@ go build
 
 ### File Selection with Modification Time
 
-When using the `--log-file-expr` option with wildcard patterns, multiple log files may match the expression. By default, all matching files are monitored. However, you can use the `--use-latest-mtime` flag to monitor only the file with the most recent modification time.
+When using the `--log-file-expr` option with wildcard patterns, multiple log files may match the expression. By default, all matching files are monitored. However, you can use the `--mtime` flag to monitor only the file with the most recent modification time.
 
 This feature is particularly useful in log rotation scenarios where:
 - Log files are rotated with timestamps (e.g., `app.log`, `app.log.1`, `app.log.2`)
 - You want to monitor only the actively written log file
 - Multiple log files exist but only the newest is relevant
 
-The modification time comparison helps ensure that you're always monitoring the most current log file, similar to the `CompareByLastUpdate` feature found in other log monitoring tools.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Flags:
   -v, --verbose                      Verbose output, useful for testing.
       --output-matching-string       Include detailed information about each matching line in output
       --force-read-from-start        Ignore cached file offset in state directory and read file(s) from beginning.
+  -M, --mtime                        When multiple files match the log file expression, only monitor the file with the most recent modification time
   -h, --help                         help for sensu-check-log
 ```
 
@@ -91,6 +92,7 @@ Flags:
 |--missing-ok               |CHECK_LOG_MISSING_OK               |
 |--invert-thresholds        |CHECK_LOG_INVERT_THRESHOLDS        |
 |--reset-state              |CHECK_LOG_RESET_STATE              |
+|--use-latest-mtime         |CHECK_LOG_USE_LATEST_MTIME         |
 
 ### Event generation
 
@@ -201,6 +203,22 @@ spec:
 
 ```
 
+Example of configuring a check to monitor only the most recently modified log file when multiple files match the pattern (useful for log rotation scenarios):
+
+```yml
+---
+type: CheckConfig
+api_version: core/v2
+metadata:
+  name: sensu-check-log-latest
+spec:  
+  command: sensu-check-log -p /var/log/ -e "application.*\.log$" -m "(?i)error" -d /tmp/sensu-check-latest-log/ --use-latest-mtime
+  stdin: true
+  runtime_assets:
+  - sensu/sensu-check-log
+
+```
+
 
 
 ## Installation from source
@@ -216,6 +234,17 @@ go build
 ```
 
 ## Additional notes
+
+### File Selection with Modification Time
+
+When using the `--log-file-expr` option with wildcard patterns, multiple log files may match the expression. By default, all matching files are monitored. However, you can use the `--use-latest-mtime` flag to monitor only the file with the most recent modification time.
+
+This feature is particularly useful in log rotation scenarios where:
+- Log files are rotated with timestamps (e.g., `app.log`, `app.log.1`, `app.log.2`)
+- You want to monitor only the actively written log file
+- Multiple log files exist but only the newest is relevant
+
+The modification time comparison helps ensure that you're always monitoring the most current log file, similar to the `CompareByLastUpdate` feature found in other log monitoring tools.
 
 ## Contributing
 

--- a/main.go
+++ b/main.go
@@ -430,7 +430,7 @@ func buildLogArray() ([]string, error) {
 				return nil, e
 			}
 
-			// If use-latest-mtime flag is set, only keep the file with the most recent modification time
+			// If mtime flag is set, only keep the file with the most recent modification time
 			if plugin.UseLatestMtime && len(matchingFiles) > 1 {
 				// Sort by modification time, most recent first
 				sort.Slice(matchingFiles, func(i, j int) bool {

--- a/main.go
+++ b/main.go
@@ -12,7 +12,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
+	"sort"
 	"strings"
+	"time"
 
 	corev2 "github.com/sensu/core/v2"
 	"github.com/sensu/sensu-plugin-sdk/sensu"
@@ -43,6 +45,7 @@ type Config struct {
 	CriticalOnly       bool
 	CheckNameTemplate  string
 	VerboseResults     bool
+	UseLatestMtime     bool
 }
 
 var (
@@ -232,6 +235,14 @@ var (
 			Usage:    "Ignore cached file offset in state directory and read file(s) from beginning.",
 			Value:    &plugin.ForceReadFromStart,
 		},
+		&sensu.PluginConfigOption[bool]{
+			Path:      "use-latest-mtime",
+			Env:       "CHECK_LOG_MTIME",
+			Argument:  "mtime",
+			Shorthand: "M",
+			Usage:     "When multiple files match the log file expression, only monitor the file with the most recent modification time",
+			Value:     &plugin.UseLatestMtime,
+		},
 	}
 )
 
@@ -321,7 +332,7 @@ func checkArgs(event *corev2.Event) (int, error) {
 	}
 	if plugin.DryRun {
 		plugin.Verbose = true
-		fmt.Printf("LogFileExpr: %s StateDir: %s\n", plugin.LogFileExpr, plugin.StateDir)
+		fmt.Printf("LogFileExpr: %s StateDir: %s UseLatestMtime: %t\n", plugin.LogFileExpr, plugin.StateDir, plugin.UseLatestMtime)
 	}
 	return sensu.CheckStateOK, nil
 }
@@ -393,11 +404,21 @@ func buildLogArray() ([]string, error) {
 		}
 
 		if filepath.IsAbs(absLogPath) {
+			// Collect all matching files with their modification times
+			type fileWithMtime struct {
+				path  string
+				mtime time.Time
+			}
+			var matchingFiles []fileWithMtime
+
 			e = filepath.Walk(absLogPath, func(path string, info os.FileInfo, err error) error {
 				if err == nil && logRegExp.MatchString(path) {
 					if filepath.IsAbs(path) {
 						if !info.IsDir() {
-							logs = append(logs, path)
+							matchingFiles = append(matchingFiles, fileWithMtime{
+								path:  path,
+								mtime: info.ModTime(),
+							})
 						}
 					} else {
 						return fmt.Errorf("path %s not absolute", path)
@@ -407,6 +428,24 @@ func buildLogArray() ([]string, error) {
 			})
 			if e != nil {
 				return nil, e
+			}
+
+			// If use-latest-mtime flag is set, only keep the file with the most recent modification time
+			if plugin.UseLatestMtime && len(matchingFiles) > 1 {
+				// Sort by modification time, most recent first
+				sort.Slice(matchingFiles, func(i, j int) bool {
+					return matchingFiles[i].mtime.After(matchingFiles[j].mtime)
+				})
+				// Keep only the most recently modified file
+				logs = append(logs, matchingFiles[0].path)
+				if plugin.Verbose {
+					fmt.Printf("Using latest modified file: %s (mtime: %v)\n", matchingFiles[0].path, matchingFiles[0].mtime)
+				}
+			} else {
+				// Add all matching files
+				for _, file := range matchingFiles {
+					logs = append(logs, file.path)
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -236,7 +236,7 @@ var (
 			Value:    &plugin.ForceReadFromStart,
 		},
 		&sensu.PluginConfigOption[bool]{
-			Path:      "use-latest-mtime",
+			Path:      "mtime",
 			Env:       "CHECK_LOG_MTIME",
 			Argument:  "mtime",
 			Shorthand: "M",

--- a/main_test.go
+++ b/main_test.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	corev2 "github.com/sensu/core/v2"
 	"github.com/stretchr/testify/assert"
@@ -744,4 +745,45 @@ func TestProcessLogFileWithNegativeCachedOffset(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, 0, matches)
 	}
+}
+
+func TestBuildLogArrayWithLatestMtime(t *testing.T) {
+	// Setup test files with different mtimes
+	err := os.MkdirAll("./testingdata/mtime-test", 0755)
+	assert.NoError(t, err)
+	defer os.RemoveAll("./testingdata/mtime-test")
+
+	// Create first file (older)
+	file1 := "./testingdata/mtime-test/log1.log"
+	err = os.WriteFile(file1, []byte("test log 1"), 0644)
+	assert.NoError(t, err)
+
+	// Wait a bit to ensure different mtime
+	time.Sleep(10 * time.Millisecond)
+
+	// Create second file (newer)
+	file2 := "./testingdata/mtime-test/log2.log"
+	err = os.WriteFile(file2, []byte("test log 2"), 0644)
+	assert.NoError(t, err)
+
+	// Test without use-latest-mtime flag (should return both files)
+	plugin.LogFile = ""
+	plugin.LogPath = "./testingdata/mtime-test/"
+	plugin.LogFileExpr = "log.*\\.log$"
+	plugin.UseLatestMtime = false
+	plugin.Verbose = false
+
+	logs, err := buildLogArray()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(logs))
+
+	// Test with use-latest-mtime flag (should return only the newest file)
+	plugin.UseLatestMtime = true
+
+	logs, err = buildLogArray()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(logs))
+
+	// The returned file should be the newer one (log2.log)
+	assert.Contains(t, logs[0], "log2.log")
 }


### PR DESCRIPTION
When multiple files match the log file expression, only the file with the most recent modification time is monitored.
This ensures the plugin always processes the most active log file, typically the one currently being written to -- and ignores older, rotated logs.